### PR TITLE
Fix gcc 8 warning regarding strncpy usage

### DIFF
--- a/src/synth/fluid_synth.c
+++ b/src/synth/fluid_synth.c
@@ -1336,7 +1336,7 @@ fluid_synth_sysex_midi_tuning (fluid_synth_t *synth, const char *data, int len,
             *resptr++ = bank;
 
         *resptr++ = prog;
-        FLUID_STRNCPY (resptr, name, 16);
+        FLUID_MEMCPY (resptr, name, 16);
         resptr += 16;
 
         for (i = 0; i < 128; i++) {


### PR DESCRIPTION
Pulled this change from upstream fluidsynth. My gcc version is 8.3.1, I'm not entirely sure when this warning was introduced.